### PR TITLE
Add a regex to verify if the value to set is a DN

### DIFF
--- a/powerview/powerview.py
+++ b/powerview/powerview.py
@@ -1793,7 +1793,9 @@ class PowerView:
 
                 attrs['value'] = list(set(attrs['value'] + temp_list))
             elif args.set:
-                attrs['value'] = list(set(attrs['value']))
+                #In case the value is a Distinguished Name
+                if not re.search(r'^((CN=([^,]*)),)?((((?:CN|OU)=[^,]+,?)+),)?((DC=[^,]+,?)+)$', str(attrs['value'])):
+                    attrs['value'] = list(set(attrs['value']))
 
             attr_key = attrs['attribute']
             attr_val = attrs['value']

--- a/powerview/powerview.py
+++ b/powerview/powerview.py
@@ -1791,7 +1791,12 @@ class PowerView:
                 elif isinstance(targetobject[0]["attributes"][attrs['attribute']], list):
                     temp_list = targetobject[0]["attributes"][attrs['attribute']]
 
-                attrs['value'] = list(set(attrs['value'] + temp_list))
+                #In case the value a Distinguished Name we retransform it into a list to append it
+                if re.search(r'^((CN=([^,]*)),)?((((?:CN|OU)=[^,]+,?)+),)?((DC=[^,]+,?)+)$', str(attrs['value'])):
+                    attrs['value'] = list(set(list(attrs['value'].split('\n') + temp_list)))
+                    print(attrs['value'])
+                else:
+                    attrs['value'] = list(set(attrs['value'] + temp_list))
             elif args.set:
                 #In case the value is a Distinguished Name
                 if not re.search(r'^((CN=([^,]*)),)?((((?:CN|OU)=[^,]+,?)+),)?((DC=[^,]+,?)+)$', str(attrs['value'])):

--- a/powerview/utils/helpers.py
+++ b/powerview/utils/helpers.py
@@ -162,7 +162,11 @@ def ini_to_dict(obj):
         return None
     for k in t['dummy_section'].keys():
         d['attribute'] = k
-        d['value'] = t.getlist('dummy_section', k)
+        #In case the value is a Distinguished Name
+        if re.search(r'^((CN=([^,]*)),)?((((?:CN|OU)=[^,]+,?)+),)?((DC=[^,]+,?)+)$', t.get('dummy_section', k)):
+            d['value'] = t.get('dummy_section', k)
+        else:
+            d['value'] = t.getlist('dummy_section', k)
     return d
 
 def parse_object(obj):


### PR DESCRIPTION
Hi guy, just a PR to modify the `Set-DomainObject` function. I have added a regex in the main function and in the `ini_to_dict()` helper to verify if the value to set is a Distinguished Name. If yes, it will set the value without building a list, which avoid to split the DN with its ','.

Not sure that is the best solution, but at least it works :smile: 