### PR TITLE
Add extra SID presence checks (GPO case)

### DIFF
--- a/powerview/powerview.py
+++ b/powerview/powerview.py
@@ -1758,6 +1758,8 @@ class PowerView:
         setattr(args,'targetidentity_dn', targetidentity_dn)
         if targetidentity_dn.upper().startswith("OU="):
             logging.info('Target identity is an OU')
+        elif targetidentity_dn.upper().startswith("CN={"):
+            logging.info('Target identity is a GPO')
         else:
             targetidentity_sid = target_entries[0]['attributes']['objectSid']
             setattr(args,'targetidentity_sid', targetidentity_sid)
@@ -1789,9 +1791,12 @@ class PowerView:
             logging.error('Principal Identity object not found in domain')
             return
         principalidentity_dn = principal_entries[0]['attributes']['distinguishedName']
-        principalidentity_sid = principal_entries[0]['attributes']['objectSid']
         setattr(args,'principalidentity_dn', principalidentity_dn)
-        setattr(args,'principalidentity_sid', principalidentity_sid)
+        if principalidentity_dn.upper().startswith("OU="):
+            logging.info('Principal identity is an OU')
+        else:
+            principalidentity_sid = principal_entries[0]['attributes']['objectSid']
+            setattr(args,'principalidentity_sid', principalidentity_sid)
         logging.info(f'Found principal identity dn {principalidentity_dn}')
 
         target_entries = self.get_domainobject(identity=args.targetidentity)
@@ -1799,9 +1804,14 @@ class PowerView:
             logging.error('Target Identity object not found in domain')
             return
         targetidentity_dn = target_entries[0]['attributes']['distinguishedName']
-        targetidentity_sid = target_entries[0]['attributes']['objectSid']
         setattr(args,'targetidentity_dn', targetidentity_dn)
-        setattr(args,'targetidentity_sid', targetidentity_sid)
+        if targetidentity_dn.upper().startswith("OU="):
+            logging.info('Target identity is an OU')
+        elif targetidentity_dn.upper().startswith("CN={"):
+            logging.info('Target identity is a GPO')
+        else:
+            targetidentity_sid = target_entries[0]['attributes']['objectSid']
+            setattr(args,'targetidentity_sid', targetidentity_sid)
         logging.info(f'Found target identity dn {targetidentity_dn}')
         entries = self.get_domainobject(identity=args.principalidentity)
         if len(entries) == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ldap3
 future
 validators
 pycryptodome
+chardet


### PR DESCRIPTION
Hey @aniqfakhrul!

Spotted a bug when trying to remove an object ACL in case of `-TargetIdentity` being a GPO (SID value is absent), so there're a few extra SID presence checks in this PR.