### PR TITLE
Fixed "memberOf" typo in get_domainuser

### DIFF
--- a/powerview/powerview.py
+++ b/powerview/powerview.py
@@ -188,7 +188,7 @@ class PowerView:
 		def_prop = [
 			'servicePrincipalName', 'objectCategory', 'objectGUID', 'primaryGroupID', 'userAccountControl',
 			'sAMAccountType', 'adminCount', 'cn', 'name', 'sAMAccountName', 'distinguishedName', 'mail',
-			'description', 'lastLogoff', 'lastLogon', 'memberof', 'objectSid', 'userPrincipalName', 
+			'description', 'lastLogoff', 'lastLogon', 'memberOf', 'objectSid', 'userPrincipalName', 
 			'pwdLastSet', 'badPwdCount', 'badPasswordTime', 'msDS-SupportedEncryptionTypes'
 		]
 		


### PR DESCRIPTION
The `get_domainforeignuser` function was failing since it couldn't access `memberOf` attribute from queried users due to typo in `get_domainuser` function

![image](https://github.com/user-attachments/assets/9c5cfa06-f25c-49ff-970d-65910c9fc5f8)

![image](https://github.com/user-attachments/assets/2c242bc7-e2e5-49d4-ad08-3272d4ffd8ba)
