### PR TITLE
Fix for get_domainforeigngroupmember

### DIFF
--- a/powerview/powerview.py
+++ b/powerview/powerview.py
@@ -1019,7 +1019,7 @@ class PowerView:
 		return entries
 
 	def get_domainforeigngroupmember(self, args=None):
-		group_members = self.get_domaingroupmember(multiple=True)
+		group_members = self.get_domaingroupmember(identity='*', multiple=True)
 		cur_domain_sid = self.get_domain()[0]['attributes']['objectSid']
 
 		if not group_members:


### PR DESCRIPTION
Small fix for `Get-DomainForeignGroupMember`, which was failing due to missing `identity` argument when calling `get_domaingroupmember`

![image](https://github.com/user-attachments/assets/39d44e4c-ab13-4932-a739-9d052be16163)
