### PR TITLE
fix: cross-trust RPC auth domain in Get-DomainCA -CheckAll

### DIFF
--- a/powerview/modules/ca.py
+++ b/powerview/modules/ca.py
@@ -206,6 +206,9 @@ class CAEnum:
                     continue
 
                 entry_rrp = self.get_rrp_config(computer_name=entry["attributes"]["dNSHostName"], ca=entry["attributes"]["name"])
+                if not entry_rrp:
+                    logging.warning(f"[CAEnum] Skipping CA {entry['attributes']['name']} — could not read registry configuration")
+                    continue
                 aces = entry_rrp["aces"].aces
 
                 # Access Rights + owner

--- a/powerview/utils/connections.py
+++ b/powerview/utils/connections.py
@@ -745,6 +745,7 @@ class CONNECTION:
 		self.username = args.username
 		self.password = args.password
 		self.domain = args.domain
+		self.auth_domain = args.domain  # Preserved for RPC auth (self.domain may change to DC's domain after bind)
 		self.lmhash = args.lmhash
 		self.nthash = args.nthash
 		self.use_kerberos = args.use_kerberos
@@ -2343,7 +2344,7 @@ class CONNECTION:
 			host = self.dc_ip
 
 		if not domain:
-			domain = self.domain
+			domain = getattr(self, 'auth_domain', self.domain)
 
 		if not username:
 			username = self.username


### PR DESCRIPTION
- Preserve user's auth domain (self.auth_domain) in CONNECTION init, separate from self.domain which changes to DC's domain after bind
- Use auth_domain in connectRPCTransport() so cross-trust users authenticate with their home domain instead of the DC's domain
- Handle get_rrp_config() failure gracefully instead of crashing with 'bool object is not subscriptable'