### PR TITLE
fix: Get-DomainObjectOwner -Where crashes with "Key not available"

### DIFF
--- a/powerview/modules/ldapattack.py
+++ b/powerview/modules/ldapattack.py
@@ -1309,20 +1309,20 @@ class ObjectOwner:
 	def __init__(self, entry):
 		try:
 			self.__target_samaccountname = entry["attributes"]["sAMAccountName"][0] if isinstance(entry["attributes"]["sAMAccountName"],list) else entry["attributes"]["sAMAccountName"]
-		except IndexError as e:
-			pass
+		except (IndexError, KeyError):
+			self.__target_samaccountname = None
 		try:
 			self.__target_sid = entry["attributes"]["objectSid"][0] if isinstance(entry["attributes"]["objectSid"], list) else entry["attributes"]["objectSid"]
-		except IndexError as e:
-			pass
+		except (IndexError, KeyError):
+			self.__target_sid = None
 		try:
 			self.__target_dn = entry["attributes"]["distinguishedName"][0] if isinstance(entry["attributes"]["distinguishedName"], list) else entry["attributes"]["distinguishedName"]
-		except IndexError as e:
-			pass
+		except (IndexError, KeyError):
+			self.__target_dn = None
 		try:
 			self.__target_secdesc = entry["attributes"]["nTSecurityDescriptor"][0] if isinstance(entry["attributes"]["nTSecurityDescriptor"], list) else entry["attributes"]["nTSecurityDescriptor"]
-		except IndexError as e:
-			pass
+		except (IndexError, KeyError):
+			self.__target_secdesc = None
 		self.__target_securitydescriptor = ldaptypes.SR_SECURITY_DESCRIPTOR(data=self.__target_secdesc)
 
 		self.new_owner_samaccountname = None

--- a/powerview/utils/formatter.py
+++ b/powerview/utils/formatter.py
@@ -437,7 +437,7 @@ class FORMATTER:
                         if str(right).casefold() in str(temp_entry['attributes'][left]).casefold():
                             temp_alter_entries.append(entry)
                     except KeyError:
-                        return None
+                        continue
                 elif isinstance(entry['attributes'],list):
                     temp_aces = []
                     for ace in entry['attributes']:


### PR DESCRIPTION
- ObjectOwner.__init__ caught IndexError but not KeyError, crashing on AD objects that legitimately lack sAMAccountName (trust objects, LAPS secrets, GPOs, containers — 78% of domain objects). Catch both and set missing attributes to None.
- alter_entries contains operator aborted entire filter with return None on first missing key, inconsistent with = and not operators which use pass. Change to continue so the filter skips entries lacking the key.