### PR TITLE
feat: add Get-DomainTrustMapping to recursively enumerate trusts

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Clear-Cache                    Get-DomainRBCD                 Get-TrustKey      
 ConvertFrom-SID                Get-DomainSCCM                 Get-WDS                        Remove-OU                      history
 ConvertFrom-UACValue           Get-DomainTrust                Invoke-ASREPRoast              Remove-ShadowCred              taskkill
 Disable-DomainDNSRecord        Get-DomainTrustKey             Invoke-DFSCoerce               Remove-ShadowCredential        tasklist
+                               Get-DomainTrustMapping
 Find-ForeignGroup              Get-DomainUser                 Invoke-Kerberoast              Restart-Computer
 Find-ForeignUser               Get-DomainWDS                  Invoke-MessageBox              Restore-ADObject
 Find-LocalAdminAccess          Get-EventLog                   Invoke-PrinterBug              Restore-DomainObject
@@ -292,6 +293,7 @@ Find-LocalAdminAccess          Get-EventLog                   Invoke-PrinterBug 
 | Module | Alias | Description |
 | ------ | ----- | ---- |
 |Get-DomainTrust||Query all Domain Trusts|
+|Get-DomainTrustMapping||Recursively map all trusts reachable from the current domain. Hops into each trust partner and flattens results with `SourceName` / `TargetName` columns (mirrors PowerView.ps1's `Get-DomainTrustMapping`). Use `-NoRecurse` to limit to the starting domain.|
 |Get-DomainForeignUser|Find-ForeignUser|Query users who are in group outside of the user's domain|
 |Get-DomainForeignGroupMember|Find-ForeignGroup|Query groups with users outside of group's domain and look for foreign member|
 

--- a/powerview/__init__.py
+++ b/powerview/__init__.py
@@ -225,6 +225,8 @@ def main():
                                 pv.add_domaincatemplateacl(pv_args.template, pv_args.principalidentity, args=pv_args)
                             elif pv_args.module.casefold() == 'get-domaintrust':
                                 entries = pv.get_domaintrust(args=pv_args)
+                            elif pv_args.module.casefold() == 'get-domaintrustmapping':
+                                entries = pv.get_domaintrustmapping(args=pv_args)
                             elif pv_args.module.casefold() == 'get-domaintrustkey' or pv_args.module.casefold() == 'get-trustkey':
                                 entries = pv.get_domaintrustkey(args=pv_args)
                             elif pv_args.module.casefold() == 'convertfrom-uacvalue':

--- a/powerview/powerview.py
+++ b/powerview/powerview.py
@@ -2556,6 +2556,101 @@ class PowerView:
 			raw=raw
 		)
 
+	def get_domaintrustmapping(self, args=None, no_cache=False, no_vuln_check=False, raw=False):
+		"""
+		Recursively enumerate trustedDomain objects starting from the current domain and
+		hopping into every reachable trust partner. Mirrors PowerView.ps1's
+		Get-DomainTrustMapping by flattening results into rows with SourceName / TargetName.
+
+		Best-effort: partners we can't bind to (e.g. external forests with different creds)
+		are logged and skipped, not fatal. A (source, target) visited-set prevents cycles
+		between parent/child trusts.
+		"""
+		no_cache = args.no_cache if hasattr(args, 'no_cache') and args.no_cache else no_cache
+		no_vuln_check = args.no_vuln_check if hasattr(args, 'no_vuln_check') and args.no_vuln_check else no_vuln_check
+		raw = args.raw if hasattr(args, 'raw') and args.raw else raw
+		no_recurse = bool(getattr(args, 'no_recurse', False))
+
+		properties = [
+			'name',
+			'trustPartner',
+			'trustDirection',
+			'trustType',
+			'trustAttributes',
+			'flatName',
+			'whenCreated',
+			'whenChanged',
+			'objectGUID',
+			'securityIdentifier',
+		]
+
+		logging.debug(f"[Get-DomainTrustMapping] Starting trust enumeration from {self.domain} (recurse={not no_recurse})")
+
+		queue = [self.domain]
+		visited_domains = set()
+		visited_pairs = set()
+		results = []
+
+		while queue:
+			source_domain = queue.pop(0)
+			source_key = source_domain.lower()
+			if source_key in visited_domains:
+				continue
+			visited_domains.add(source_key)
+
+			try:
+				pv = self.get_domain_powerview(source_domain)
+			except Exception as e:
+				logging.warning(f"[Get-DomainTrustMapping] Skipping {source_domain}: cannot bind ({str(e)})")
+				continue
+
+			count = 0
+			try:
+				for entry in pv.get_domaintrust(
+					properties=properties,
+					no_cache=no_cache,
+					no_vuln_check=no_vuln_check,
+					raw=raw,
+				):
+					attrs = entry.get('attributes', {}) or {}
+					target_name = attrs.get('trustPartner') or attrs.get('name')
+					if not target_name:
+						continue
+					if isinstance(target_name, list):
+						target_name = target_name[0] if target_name else None
+						if not target_name:
+							continue
+
+					pair_key = (source_key, target_name.lower())
+					if pair_key in visited_pairs:
+						continue
+					visited_pairs.add(pair_key)
+
+					results.append({
+						'attributes': {
+							'SourceName': source_domain,
+							'TargetName': target_name,
+							'TrustType': attrs.get('trustType'),
+							'TrustAttributes': attrs.get('trustAttributes'),
+							'TrustDirection': attrs.get('trustDirection'),
+							'WhenCreated': attrs.get('whenCreated'),
+							'WhenChanged': attrs.get('whenChanged'),
+						}
+					})
+					count += 1
+
+					if not no_recurse and target_name.lower() not in visited_domains:
+						queue.append(target_name)
+			except Exception as e:
+				logging.warning(f"[Get-DomainTrustMapping] Failed to enumerate trusts on {source_domain}: {str(e)}")
+				continue
+
+			logging.debug(f"[Get-DomainTrustMapping] Found {count} trust(s) on {source_domain}")
+
+		if not results:
+			logging.error("[Get-DomainTrustMapping] No trusts discovered")
+		return results
+
 	def convertto_uacvalue(self, value, args=None, output=False):
 		if value.isdigit() or not isinstance(value, str):
 			raise ValueError("Value is not a string")

--- a/powerview/utils/completer.py
+++ b/powerview/utils/completer.py
@@ -44,6 +44,7 @@ COMMANDS = {
     'Get-DomainForeignUser':['-LDAPFilter','-Server','-Select', '-Where', '-Count', '-NoWrap', '-TableView', '-SortBy', '-OutFile'],
     'Find-ForeignUser':['-LDAPFilter','-Server','-Select', '-Where', '-Count', '-NoWrap','-OutFile'],
     'Get-DomainTrust':['-Identity','-LDAPFilter','-Properties','-SearchBase','-Server','-Select', '-Where', '-Count', '-NoWrap', '-TableView', '-SortBy', '-OutFile', '-NoCache', '-NoVulnCheck', '-Raw'],
+    'Get-DomainTrustMapping':['-Server','-Select', '-Where', '-Count', '-NoWrap', '-TableView', '-SortBy', '-OutFile', '-NoCache', '-NoVulnCheck', '-Raw', '-NoRecurse'],
     'Get-DomainTrustKey':['-Identity','-Properties','-SearchBase','-Server','-Select', '-Where', '-Count', '-NoWrap', '-TableView', '-SortBy', '-OutFile', '-NoCache', '-NoVulnCheck', '-Raw'],
     'Get-TrustKey':['-Identity','-Properties','-SearchBase','-Server','-Select', '-Where', '-Count', '-NoWrap', '-TableView', '-SortBy', '-OutFile', '-NoCache', '-NoVulnCheck', '-Raw'],
     'Get-DomainUser':['-Identity','-Properties','-LDAPFilter','-SearchBase','-Server','-Select','-Enabled','-Disabled','-RBCD', '-ShadowCred', '-Unconstrained','-PassNotRequired','-PreAuthNotRequired','-AllowDelegation','-DisallowDelegation','-AdminCount','-LockedOut','-PassExpired','-TrustedToAuth','-SPN','-MemberOf','-Department','-Where', '-Count', '-NoWrap', '-TableView', '-SortBy', '-OutFile', '-NoCache', '-NoVulnCheck', '-Raw'],

--- a/powerview/utils/connections.py
+++ b/powerview/utils/connections.py
@@ -306,7 +306,7 @@ class ConnectionPool:
 				raise ConnectionError(f"Created connection for {domain} is not alive")
 		except Exception as e:
 			self._record_connection_attempt(domain, success=False)
-			logging.error(f"Failed to create connection for domain {domain}: {str(e)}")
+			logging.warning(f"Failed to create connection for domain {domain}: {str(e)}")
 			raise
 
 		# Re-acquire lock to insert the new connection
@@ -956,7 +956,7 @@ class CONNECTION:
 			logging.debug(f"Retrieved connection for domain {domain} from pool")
 			return connection
 		except Exception as e:
-			logging.error(f"Failed to get connection for domain {domain}: {str(e)}")
+			logging.warning(f"Failed to get connection for domain {domain}: {str(e)}")
 			raise
 	
 	def maintain_connections(self):

--- a/powerview/utils/parsers.py
+++ b/powerview/utils/parsers.py
@@ -1185,6 +1185,21 @@ def powerview_arg_parse(cmd):
 	get_domaintrust_parser.add_argument('-NoVulnCheck', action='store_true', default=False, dest='no_vuln_check')
 	get_domaintrust_parser.add_argument('-Raw', action='store_true', default=False, dest='raw')
 
+	#trust mapping (recursive across reachable trust partners)
+	get_domaintrustmapping_parser = subparsers.add_parser('Get-DomainTrustMapping', exit_on_error=False)
+	get_domaintrustmapping_parser.add_argument('-Server', action='store', dest='server')
+	get_domaintrustmapping_parser.add_argument('-Select', action='store', dest='select', type=Helper.parse_select)
+	get_domaintrustmapping_parser.add_argument('-Where', action='store', dest='where')
+	get_domaintrustmapping_parser.add_argument('-TableView', nargs='?', const='default', default='', dest='tableview', help="Format the output as a table. Options: 'md', 'csv'. Defaults to standard table if no value is provided.", type=Helper.parse_tableview)
+	get_domaintrustmapping_parser.add_argument('-SortBy', action='store', dest='sort_by')
+	get_domaintrustmapping_parser.add_argument('-OutFile', action='store', dest='outfile')
+	get_domaintrustmapping_parser.add_argument('-Count', action='store_true', dest='count')
+	get_domaintrustmapping_parser.add_argument('-NoWrap', action='store_true', default=False, dest='nowrap')
+	get_domaintrustmapping_parser.add_argument('-NoCache', action='store_true', default=False, dest='no_cache')
+	get_domaintrustmapping_parser.add_argument('-NoVulnCheck', action='store_true', default=False, dest='no_vuln_check')
+	get_domaintrustmapping_parser.add_argument('-Raw', action='store_true', default=False, dest='raw')
+	get_domaintrustmapping_parser.add_argument('-NoRecurse', action='store_true', default=False, dest='no_recurse', help="Only enumerate trusts on the starting domain; skip hopping into trust partners.")
+
 	#trust key
 	get_domaintrustkey_parser = subparsers.add_parser('Get-DomainTrustKey', aliases=['Get-TrustKey'], exit_on_error=False)
 	get_domaintrustkey_parser.add_argument('-Identity', action='store', dest='identity', type=parse_identity_list)


### PR DESCRIPTION
- New command Get-DomainTrustMapping mirrors PowerView.ps1's behavior: BFS-walks every reachable trust partner and flattens results into SourceName / TargetName rows, exposing trusts that are invisible from the local domain alone 
- Adds -NoRecurse flag for the SourceName / TargetName reshape without the cross-domain hop.
- Demote two connection-pool failure logs from error to warning since the caller is already responsible for handling the raised exception.
- README updated with the new module under Domain Trust Functions.